### PR TITLE
Change from ssh to https for lib cloning

### DIFF
--- a/src/mbedos/test-bme688/.gitignore
+++ b/src/mbedos/test-bme688/.gitignore
@@ -19,6 +19,7 @@
 # Compiled Static libraries
 *.lai
 *.la
+*.a
 
 # Executables
 *.exe
@@ -41,3 +42,5 @@ cmake_build/
 
 BUILD
 .mbed
+mbed-os/
+stm32customtargets/

--- a/src/mbedos/test-bme688/mbed-os.lib
+++ b/src/mbedos/test-bme688/mbed-os.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/mbed-os.git#daf31245c4c87207bd3fd6a55302a7734305ca87
+https://github.com/teapotlaboratories/mbed-os/#daf31245c4c87207bd3fd6a55302a7734305ca87

--- a/src/mbedos/test-bme688/stm32customtargets.lib
+++ b/src/mbedos/test-bme688/stm32customtargets.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/stm32customtargets.git#648ae48049eab435aa5aac1009e85a969af599f7
+https://github.com/teapotlaboratories/stm32customtargets/#648ae48049eab435aa5aac1009e85a969af599f7

--- a/src/mbedos/test-deep-sleep/.gitignore
+++ b/src/mbedos/test-deep-sleep/.gitignore
@@ -42,3 +42,5 @@ cmake_build/
 
 BUILD
 .mbed
+mbed-os/
+stm32customtargets/

--- a/src/mbedos/test-deep-sleep/mbed-os.lib
+++ b/src/mbedos/test-deep-sleep/mbed-os.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/mbed-os.git#daf31245c4c87207bd3fd6a55302a7734305ca87
+https://github.com/teapotlaboratories/mbed-os/#daf31245c4c87207bd3fd6a55302a7734305ca87

--- a/src/mbedos/test-deep-sleep/stm32customtargets.lib
+++ b/src/mbedos/test-deep-sleep/stm32customtargets.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/stm32customtargets.git#648ae48049eab435aa5aac1009e85a969af599f7
+https://github.com/teapotlaboratories/stm32customtargets/#648ae48049eab435aa5aac1009e85a969af599f7

--- a/src/mbedos/test-flash/.gitignore
+++ b/src/mbedos/test-flash/.gitignore
@@ -19,6 +19,7 @@
 # Compiled Static libraries
 *.lai
 *.la
+*.a
 
 # Executables
 *.exe
@@ -41,3 +42,5 @@ cmake_build/
 
 BUILD
 .mbed
+mbed-os/
+stm32customtargets/

--- a/src/mbedos/test-flash/mbed-os.lib
+++ b/src/mbedos/test-flash/mbed-os.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/mbed-os.git#daf31245c4c87207bd3fd6a55302a7734305ca87
+https://github.com/teapotlaboratories/mbed-os/#daf31245c4c87207bd3fd6a55302a7734305ca87

--- a/src/mbedos/test-flash/stm32customtargets.lib
+++ b/src/mbedos/test-flash/stm32customtargets.lib
@@ -1,1 +1,1 @@
-git@github.com:teapotlaboratories/stm32customtargets.git#648ae48049eab435aa5aac1009e85a969af599f7
+https://github.com/teapotlaboratories/stm32customtargets/#648ae48049eab435aa5aac1009e85a969af599f7


### PR DESCRIPTION
[mbed] Adding library "mbed-os" from "ssh://git@github.com/teapotlaboratories/mbed-os" at rev #daf31245c4c8
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.      

Please make sure you have the correct access rights
and the repository exists.
error: Could not fetch origin